### PR TITLE
Don't convert UTC time to Unixtimestamp

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -72,7 +72,7 @@ function parser(data) {
       var value = matches[i+1];
 
       if (key === "time") {
-        obj['time'] = Date.parse(value);
+        obj['time'] = value;
       } else if (numParams.indexOf(key) >= 0) {
         obj[key] = Number(value);
       } else {


### PR DESCRIPTION
## Backgound
Usually use UTC timestamp in the case database timestamp element.

## What
Change not to convert Unixtimestamp